### PR TITLE
Allow installation of the package on PHP 8.0

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  tests:
+    name: Tests on PHP ${{ matrix.php }}
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        php: ['7.2', '7.3', '7.4']
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2.3.4
+      - uses: shivammathur/setup-php@2.9.0
+        with:
+          php-version: ${{ matrix.php }}
+      - name: Install dependencies
+        run: composer install
+      - name: Configure PHPUnit problem matchers
+        run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
+      - name: Run tests
+        run: ./vendor/bin/phpunit

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -6,19 +6,22 @@ on:
 
 jobs:
   tests:
-    name: Tests on PHP ${{ matrix.php }}
+    name: Tests on PHP ${{ matrix.php }} ${{ matrix.dependencies }}
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        php: ['7.2', '7.3', '7.4']
+        php: ['7.2', '7.3', '7.4', '8.0']
+        dependencies: ['', '--prefer-lowest --prefer-stable']
     steps:
       - name: Checkout
         uses: actions/checkout@v2.3.4
       - uses: shivammathur/setup-php@2.9.0
         with:
           php-version: ${{ matrix.php }}
+      - name: Remove Composer lockfile
+        run: rm composer.lock
       - name: Install dependencies
-        run: composer install
+        run: composer update --no-interaction --prefer-dist ${{ matrix.dependencies }}
       - name: Configure PHPUnit problem matchers
         run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
       - name: Run tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,0 @@
-language: php
-
-dist: trusty
-
-php:
-  - 7.2
-  - 7.3
-
-before_script: composer install

--- a/composer.json
+++ b/composer.json
@@ -10,12 +10,12 @@
         }
     ],
     "require": {
-        "php": "^7.2",
+        "php": "^7.2|~8.0.0",
         "bramus/ansi-php": "^3.0.3"
     },
     "require-dev": {
         "monolog/monolog": "~2.0",
-        "phpunit/phpunit": "~7.0"
+        "phpunit/phpunit": "~7.0|^9.4"
     },
     "autoload": {
         "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f81ae9d45d5b08f5730fc678346367c8",
+    "content-hash": "9a458fad755c59f302c89183d43c448c",
     "packages": [
         {
             "name": "bramus/ansi-php",
@@ -44,6 +44,10 @@
                 }
             ],
             "description": "ANSI Control Functions and ANSI Control Sequences (Colors, Erasing, etc.) for PHP CLI Apps",
+            "support": {
+                "issues": "https://github.com/bramus/ansi-php/issues",
+                "source": "https://github.com/bramus/ansi-php/tree/master"
+            },
             "time": "2019-12-03T09:04:38+00:00"
         }
     ],
@@ -102,6 +106,10 @@
                 "constructor",
                 "instantiate"
             ],
+            "support": {
+                "issues": "https://github.com/doctrine/instantiator/issues",
+                "source": "https://github.com/doctrine/instantiator/tree/master"
+            },
             "time": "2019-10-21T16:45:58+00:00"
         },
         {
@@ -183,6 +191,10 @@
                 "logging",
                 "psr-3"
             ],
+            "support": {
+                "issues": "https://github.com/Seldaek/monolog/issues",
+                "source": "https://github.com/Seldaek/monolog/tree/2.0.1"
+            },
             "time": "2019-11-13T10:27:43+00:00"
         },
         {
@@ -231,6 +243,10 @@
                 "object",
                 "object graph"
             ],
+            "support": {
+                "issues": "https://github.com/myclabs/DeepCopy/issues",
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.9.3"
+            },
             "time": "2019-08-09T12:45:53+00:00"
         },
         {
@@ -286,6 +302,10 @@
                 }
             ],
             "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
+            "support": {
+                "issues": "https://github.com/phar-io/manifest/issues",
+                "source": "https://github.com/phar-io/manifest/tree/master"
+            },
             "time": "2018-07-08T19:23:20+00:00"
         },
         {
@@ -333,6 +353,10 @@
                 }
             ],
             "description": "Library for handling version information and constraints",
+            "support": {
+                "issues": "https://github.com/phar-io/version/issues",
+                "source": "https://github.com/phar-io/version/tree/master"
+            },
             "time": "2018-07-08T19:19:57+00:00"
         },
         {
@@ -385,6 +409,10 @@
                 "reflection",
                 "static analysis"
             ],
+            "support": {
+                "issues": "https://github.com/phpDocumentor/ReflectionCommon/issues",
+                "source": "https://github.com/phpDocumentor/ReflectionCommon/tree/2.0.0"
+            },
             "time": "2018-08-07T13:53:10+00:00"
         },
         {
@@ -436,6 +464,10 @@
                 }
             ],
             "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
+            "support": {
+                "issues": "https://github.com/phpDocumentor/ReflectionDocBlock/issues",
+                "source": "https://github.com/phpDocumentor/ReflectionDocBlock/tree/4.3.2"
+            },
             "time": "2019-09-12T14:27:41+00:00"
         },
         {
@@ -483,6 +515,10 @@
                 }
             ],
             "description": "A PSR-5 based resolver of Class names, Types and Structural Element Names",
+            "support": {
+                "issues": "https://github.com/phpDocumentor/TypeResolver/issues",
+                "source": "https://github.com/phpDocumentor/TypeResolver/tree/0.7.2"
+            },
             "time": "2019-08-22T18:11:29+00:00"
         },
         {
@@ -546,6 +582,10 @@
                 "spy",
                 "stub"
             ],
+            "support": {
+                "issues": "https://github.com/phpspec/prophecy/issues",
+                "source": "https://github.com/phpspec/prophecy/tree/master"
+            },
             "time": "2019-10-03T11:07:50+00:00"
         },
         {
@@ -609,6 +649,10 @@
                 "testing",
                 "xunit"
             ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/master"
+            },
             "time": "2018-10-31T16:06:48+00:00"
         },
         {
@@ -659,6 +703,10 @@
                 "filesystem",
                 "iterator"
             ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-file-iterator/issues",
+                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/2.0.2"
+            },
             "time": "2018-09-13T20:33:42+00:00"
         },
         {
@@ -700,6 +748,10 @@
             "keywords": [
                 "template"
             ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-text-template/issues",
+                "source": "https://github.com/sebastianbergmann/php-text-template/tree/1.2.1"
+            },
             "time": "2015-06-21T13:50:34+00:00"
         },
         {
@@ -749,6 +801,10 @@
             "keywords": [
                 "timer"
             ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-timer/issues",
+                "source": "https://github.com/sebastianbergmann/php-timer/tree/master"
+            },
             "time": "2019-06-07T04:22:29+00:00"
         },
         {
@@ -798,6 +854,11 @@
             "keywords": [
                 "tokenizer"
             ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-token-stream/issues",
+                "source": "https://github.com/sebastianbergmann/php-token-stream/tree/3.1.1"
+            },
+            "abandoned": true,
             "time": "2019-09-17T06:23:10+00:00"
         },
         {
@@ -882,6 +943,10 @@
                 "testing",
                 "xunit"
             ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/phpunit/issues",
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/7.5.18"
+            },
             "time": "2019-12-06T05:14:37+00:00"
         },
         {
@@ -929,6 +994,9 @@
                 "psr",
                 "psr-3"
             ],
+            "support": {
+                "source": "https://github.com/php-fig/log/tree/1.1.2"
+            },
             "time": "2019-11-01T11:05:21+00:00"
         },
         {
@@ -974,6 +1042,10 @@
             ],
             "description": "Looks up which function or method a line of code belongs to",
             "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/issues",
+                "source": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/tree/master"
+            },
             "time": "2017-03-04T06:30:41+00:00"
         },
         {
@@ -1038,6 +1110,10 @@
                 "compare",
                 "equality"
             ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/comparator/issues",
+                "source": "https://github.com/sebastianbergmann/comparator/tree/master"
+            },
             "time": "2018-07-12T15:12:46+00:00"
         },
         {
@@ -1094,6 +1170,10 @@
                 "unidiff",
                 "unified diff"
             ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/diff/issues",
+                "source": "https://github.com/sebastianbergmann/diff/tree/master"
+            },
             "time": "2019-02-04T06:01:07+00:00"
         },
         {
@@ -1147,6 +1227,10 @@
                 "environment",
                 "hhvm"
             ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/environment/issues",
+                "source": "https://github.com/sebastianbergmann/environment/tree/4.2.3"
+            },
             "time": "2019-11-20T08:46:58+00:00"
         },
         {
@@ -1214,6 +1298,10 @@
                 "export",
                 "exporter"
             ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/exporter/issues",
+                "source": "https://github.com/sebastianbergmann/exporter/tree/master"
+            },
             "time": "2019-09-14T09:02:43+00:00"
         },
         {
@@ -1265,6 +1353,10 @@
             "keywords": [
                 "global state"
             ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/global-state/issues",
+                "source": "https://github.com/sebastianbergmann/global-state/tree/2.0.0"
+            },
             "time": "2017-04-27T15:39:26+00:00"
         },
         {
@@ -1312,6 +1404,10 @@
             ],
             "description": "Traverses array structures and object graphs to enumerate all referenced objects",
             "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/object-enumerator/issues",
+                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/master"
+            },
             "time": "2017-08-03T12:35:26+00:00"
         },
         {
@@ -1357,6 +1453,10 @@
             ],
             "description": "Allows reflection of object attributes, including inherited and non-public ones",
             "homepage": "https://github.com/sebastianbergmann/object-reflector/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/object-reflector/issues",
+                "source": "https://github.com/sebastianbergmann/object-reflector/tree/master"
+            },
             "time": "2017-03-29T09:07:27+00:00"
         },
         {
@@ -1410,6 +1510,10 @@
             ],
             "description": "Provides functionality to recursively process PHP variables",
             "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/recursion-context/issues",
+                "source": "https://github.com/sebastianbergmann/recursion-context/tree/master"
+            },
             "time": "2017-03-03T06:23:57+00:00"
         },
         {
@@ -1452,6 +1556,10 @@
             ],
             "description": "Provides a list of PHP built-in functions that operate on resources",
             "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/resource-operations/issues",
+                "source": "https://github.com/sebastianbergmann/resource-operations/tree/master"
+            },
             "time": "2018-10-04T04:07:39+00:00"
         },
         {
@@ -1495,6 +1603,10 @@
             ],
             "description": "Library that helps with managing the version number of Git-hosted PHP projects",
             "homepage": "https://github.com/sebastianbergmann/version",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/version/issues",
+                "source": "https://github.com/sebastianbergmann/version/tree/master"
+            },
             "time": "2016-10-03T07:35:21+00:00"
         },
         {
@@ -1553,6 +1665,9 @@
                 "polyfill",
                 "portable"
             ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-ctype/tree/master"
+            },
             "time": "2019-11-27T13:56:44+00:00"
         },
         {
@@ -1593,6 +1708,10 @@
                 }
             ],
             "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
+            "support": {
+                "issues": "https://github.com/theseer/tokenizer/issues",
+                "source": "https://github.com/theseer/tokenizer/tree/master"
+            },
             "time": "2019-06-13T22:48:21+00:00"
         },
         {
@@ -1641,6 +1760,10 @@
                 "check",
                 "validate"
             ],
+            "support": {
+                "issues": "https://github.com/webmozart/assert/issues",
+                "source": "https://github.com/webmozart/assert/tree/master"
+            },
             "time": "2019-11-24T13:36:37+00:00"
         }
     ],
@@ -1650,7 +1773,8 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^7.2"
+        "php": "^7.2|~8.0.0"
     },
-    "platform-dev": []
+    "platform-dev": [],
+    "plugin-api-version": "2.0.0"
 }

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 # Monolog Colored Line Formatter
 
-[![Build Status](https://img.shields.io/travis/bramus/monolog-colored-line-formatter.svg?style=flat-square)](http://travis-ci.org/bramus/monolog-colored-line-formatter) [![Source](http://img.shields.io/badge/source-bramus/monolog--colored--line--formatter-blue.svg?style=flat-square)](https://github.com/bramus/monolog-colored-line-formatter) [![Version](https://img.shields.io/packagist/v/bramus/monolog-colored-line-formatter.svg?style=flat-square)](https://packagist.org/packages/bramus/monolog-colored-line-formatter) [![Downloads](https://img.shields.io/packagist/dt/bramus/monolog-colored-line-formatter.svg?style=flat-square)](https://packagist.org/packages/bramus/monolog-colored-line-formatter/stats) [![License](https://img.shields.io/packagist/l/bramus/monolog-colored-line-formatter.svg?style=flat-square)](https://github.com/bramus/monolog-colored-line-formatter/blob/master/LICENSE.txt)
+![Build Status](https://github.com/bramus/monolog-colored-line-formatter/workflows/CI/badge.svg) [![Source](http://img.shields.io/badge/source-bramus/monolog--colored--line--formatter-blue.svg?style=flat-square)](https://github.com/bramus/monolog-colored-line-formatter) [![Version](https://img.shields.io/packagist/v/bramus/monolog-colored-line-formatter.svg?style=flat-square)](https://packagist.org/packages/bramus/monolog-colored-line-formatter) [![Downloads](https://img.shields.io/packagist/dt/bramus/monolog-colored-line-formatter.svg?style=flat-square)](https://packagist.org/packages/bramus/monolog-colored-line-formatter/stats) [![License](https://img.shields.io/packagist/l/bramus/monolog-colored-line-formatter.svg?style=flat-square)](https://github.com/bramus/monolog-colored-line-formatter/blob/master/LICENSE.txt)
 
 A Formatter for Monolog with color support
 Built by Bramus! - [https://www.bram.us/](https://www.bram.us/)
@@ -136,7 +136,7 @@ Please refer to [the `bramus/ansi-php` documentation](https://github.com/bramus/
 
 - If PHPUnit is not installed globally, install it locally through composer by running `composer install --dev`. Run the tests themselves by calling `vendor/bin/phpunit`.
 
-Unit tests are also automatically run [on Travis CI](http://travis-ci.org/bramus/monolog-colored-line-formatter)
+Unit tests are also automatically run [on GitHub Actions](https://github.com/bramus/monolog-colored-line-formatter/actions?query=workflow%3ACI)
 
 ## License
 

--- a/tests/ColoredLineFormatterTest.php
+++ b/tests/ColoredLineFormatterTest.php
@@ -8,13 +8,13 @@ use Bramus\Ansi\ControlSequences\EscapeSequences\Enums\SGR;
 
 class ColoredLineFormatterTest extends \PHPUnit\Framework\TestCase
 {
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->ansi = new Ansi(new BufferWriter());
         $this->clf = new ColoredLineFormatter();
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         // ...
     }


### PR DESCRIPTION
This contribution makes possible to install the package on PHP 8.0.

To do so:
 * CI has been moved from travis-ci.org to GitHub Actions. Travis CI does not have the stable PHP 8.0 available yet. Also [travis-ci.org will be closed at the end of the year](https://docs.travis-ci.com/user/migrate/open-source-repository-migration/#frequently-asked-questions) and the [migration to travis-ci.com can be a bit annoying for OSS projects](https://blog.travis-ci.com/2020-11-02-travis-ci-new-billing#building-on-a-public-repositories-only).
 * PHPUnit 9.4 has been added to the list of the acceptable versions so we can pull a version compatible with PHP 8.0 to run the tests.
 * Composer lockfile is no more taken in the CI pipeline so we can pull the appropriate versions of the dependencies according to the environment. However both end of the spectrum of possible dependencies are now tested (lowest and current).