### PR TITLE
Relax version constraint for PHP 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "php": "^7.2|~8.0.0",
+        "php": "^7.2|^8.0",
         "bramus/ansi-php": "^3.0.3"
     },
     "require-dev": {


### PR DESCRIPTION
This allows installations with PHP 8.1