### PR TITLE
fix: incorrect phpdoc for ColoredLineFormatter::__construct

### DIFF
--- a/src/Formatter/ColoredLineFormatter.php
+++ b/src/Formatter/ColoredLineFormatter.php
@@ -19,8 +19,8 @@ class ColoredLineFormatter extends \Monolog\Formatter\LineFormatter
 
     /**
      * @param ColorSchemeInterface|null $colorScheme
-     * @param null $format The format of the message
-     * @param null $dateFormat The format of the timestamp: one supported by DateTime::format
+     * @param string|null $format The format of the message
+     * @param string|null $dateFormat The format of the timestamp: one supported by DateTime::format
      * @param bool $allowInlineLineBreaks Whether to allow inline line breaks in log entries
      * @param bool $ignoreEmptyContextAndExtra
      */


### PR DESCRIPTION
Phpstan was raising the following errors.

```
----------------------------------------------------------------------------------------------------------------------------- 
Parameter #2 $format of method Bramus\Monolog\Formatter\ColoredLineFormatter::__construct() expects null, string given.      
Parameter #3 $dateFormat of method Bramus\Monolog\Formatter\ColoredLineFormatter::__construct() expects null, string given.  
----------------------------------------------------------------------------------------------------------------------------- 
```

`$format` and `$dateFormat` is documented as `null` type but it should be `string|null`.
